### PR TITLE
Disables build GH action on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@
 ## JBIJPPTPL
 
 name: Build
-on: [push, pull_request]
+on: [pull_request]
 jobs:
 
   # Run Gradle Wrapper Validation Action to verify the wrapper's checksum


### PR DESCRIPTION
The develop and main branches are protected so no code can be merged in them without making a PR in which case this action will always run