### PR TITLE
Refactor Gradle dependencies to use version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,20 +5,13 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
-    // Java support
     id("java")
-    // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.9.0"
-    // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.15.0"
-    // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "2.1.2"
-    // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.23.1"
-    // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "11.5.1"
-    // apollo client - read more: https://github.com/apollographql/apollo-android
-    id("com.apollographql.apollo3") version "3.8.2"
+    alias(libs.plugins.kotlin)
+    alias(libs.plugins.gradleIntelliJPlugin)
+    alias(libs.plugins.changelog)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.apollo3)
 }
 
 group = properties("pluginGroup")
@@ -30,8 +23,8 @@ repositories {
 }
 
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
-    implementation("com.apollographql.apollo3:apollo-runtime:3.8.2")
+    detektPlugins(libs.detekt.formatting)
+    implementation(libs.apollo.runtime)
 }
 
 // Configure gradle-intellij-plugin plugin.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,19 @@
+[versions]
+kotlin = "1.9.0"
+changelog = "2.1.2" # https://github.com/JetBrains/gradle-changelog-plugin
+gradleIntelliJPlugin = "1.15.0" # https://github.com/JetBrains/gradle-intellij-plugin
+detekt = "1.23.1" # https://detekt.github.io/detekt/gradle.html
+ktlint = "11.5.1" # https://github.com/JLLeitschuh/ktlint-gradle
+apollo3 = "3.8.2" # https://github.com/apollographql/apollo-kotlin
+
+[libraries]
+detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+apollo-runtime = { group = "com.apollographql.apollo3", name = "apollo-runtime", version.ref = "apollo3" }
+
+[plugins]
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
+gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntelliJPlugin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+apollo3 = { id = "com.apollographql.apollo3", version.ref = "apollo3" }


### PR DESCRIPTION
This commit refactors the build.gradle.kts file to take advantage of Gradle's version catalog feature. Instead of hardcoding plugin versions and dependencies directly within the file, these are now maintained in the libs.versions.toml file. This makes it easier to manage project dependencies as they are now centralized in one file. This pattern is efficient and improves the readability and maintainability of the build file.