### PR TITLE
Add Workspace ID to LinearRepository

### DIFF
--- a/src/main/kotlin/dev/mayankmkh/intellij/linear/LinearRepositoryEditor.kt
+++ b/src/main/kotlin/dev/mayankmkh/intellij/linear/LinearRepositoryEditor.kt
@@ -2,13 +2,20 @@ package dev.mayankmkh.intellij.linear
 
 import com.intellij.openapi.project.Project
 import com.intellij.tasks.config.BaseRepositoryEditor
+import com.intellij.ui.components.JBLabel
 import com.intellij.util.Consumer
+import com.intellij.util.ui.FormBuilder
+import javax.swing.JComponent
+import javax.swing.JTextField
 
 class LinearRepositoryEditor(
     project: Project,
     linearRepository: LinearRepository,
     changeListener: Consumer<in LinearRepository>,
 ) : BaseRepositoryEditor<LinearRepository>(project, linearRepository, changeListener) {
+    private lateinit var myWorkspaceLabel: JBLabel
+    private lateinit var myWorkspaceText: JTextField
+
     init {
         myPasswordLabel.text = "API key:"
         myUsernameLabel.text = "Team ID:"
@@ -27,6 +34,21 @@ class LinearRepositoryEditor(
             }
         myUserNameText.document.addDocumentListener(testUpdateListener)
         myPasswordText.document.addDocumentListener(testUpdateListener)
+    }
+
+    override fun createCustomPanel(): JComponent? {
+        myWorkspaceLabel = JBLabel("Workspace ID:")
+        myWorkspaceText = JTextField(myRepository.workspaceId)
+        installListener(myWorkspaceText)
+        return FormBuilder.createFormBuilder()
+            .addLabeledComponent(myWorkspaceLabel, myWorkspaceText)
+            .panel
+    }
+
+    override fun apply() {
+        myRepository.workspaceId = myWorkspaceText.text.trim()
+        super.apply()
+        updateTestButton()
     }
 
     private fun updateTestButton() {


### PR DESCRIPTION
Enhanced LinearRepository and corresponding Editor to include a 'Workspace ID' field. Users can now specify a workspace ID during configuration, which is stored and presented alongside the team ID. This will allow specific workspace handling within a Linear team.

Fixes #155 